### PR TITLE
Always return original return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ function load (file, cb) {
 Ironically, the prototype feature makes this module twice as
 complicated as necessary.
 
-To check whether you function has been called, use `fn.called`:
+To check whether you function has been called, use `fn.called`. Once the
+function is called for the first time the return value of the original
+function is saved in `fn.value` and subsequent calls will continue to
+return this value.
 
 ```javascript
 var once = require('once')

--- a/once.js
+++ b/once.js
@@ -11,9 +11,9 @@ once.proto = once(function () {
 
 function once (fn) {
   var f = function () {
-    if (f.called) return
+    if (f.called) return f.value
     f.called = true
-    return fn.apply(this, arguments)
+    return f.value = fn.apply(this, arguments)
   }
   f.called = false
   return f

--- a/test/once.js
+++ b/test/once.js
@@ -13,7 +13,7 @@ test('once', function (t) {
     t.same(f, i === 0 ? 0 : 1)
     var g = foo.call(1, 1)
     t.ok(foo.called)
-    t.same(g, i === 0 ? 3 : undefined)
+    t.same(g, 3)
     t.same(f, 1)
   }
   t.end()


### PR DESCRIPTION
I needed my `once()`'ed function to continue returning the original return value of the first function call so I made these changes:
- Change `once()` so that when it is called for the first time the return value of the original function is saved in `fn.value` and any subsequent calls will continue to return this same value.
- Add a test for this behavior.
- Document this behavior in the readme.
