### PR TITLE
Use a valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "single"
   ],
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
-  "license": "BSD"
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
This tiny patch changes `"BSD"` to `"BSD-2-Clause"` in `package.json`. As it turns out, the former is not a valid SPDX license identifier, in part because there are several variants of the BSD license to choose from. http://spdx.org/licenses has the most recent list.

I am on something of a semi-automated crusade against bad SPDX hygiene to the npm community, and I did notice that a few of your very popular packages---fstream, json-stringify-safe, node-graceful-fs, node-tar, osenv, and sax-js---also use `"BSD"`. If you'd like me to send PRs for those as well (and don't mind a bit of boilerplate in the PR messages), I'll be happy to sick my scripts on them.

We've crossed paths a few times at OaklandJS, but never ended up in the same conversation. I hope we get a chance to meet properly soon. Until I can thank you personally: Thanks much for hard work on npm!
imes at OaklandJS, but never ended up in the same conversation. I hope we get a chance to meet properly soon. Until I can thank you personally: Thanks much for hard work on npm!