### PR TITLE
once.strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,31 @@ function load (cb) {
   })
 }
 ```
+
+## `once.strict(func)`
+
+Throw an error if the function is called twice.
+
+Some functions are expected to be called only once. Using `once` for them would
+potentially hide logical errors.
+
+In the example below, the `greet` function has to call the callback only once:
+
+```javascript
+function greet (name, cb) {
+  // return is missing from the if statement
+  // when no name is passed, the callback is called twice
+  if (!name) cb('Hello anonymous')
+  cb('Hello ' + name)
+}
+
+function log (msg) {
+  console.log(msg)
+}
+
+// this will print 'Hello anonymous' but the logical error will be missed
+greet(null, once(msg))
+
+// once.strict will print 'Hello anonymous' and throw an error when the callback will be called the second time
+greet(null, once.strict(msg))
+```

--- a/once.js
+++ b/once.js
@@ -1,4 +1,16 @@
 var wrappy = require('wrappy')
+var once = secondCallHandler(function (f) { return f.value })
+
+once.strict = wrappy(secondCallHandler(function (f) {
+  throw new Error(f.onceError || createErrorMsg(f))
+}))
+
+function createErrorMsg (f) {
+  return f.srcName
+    ? f.srcName + " shouln't be called more than once"
+    : "Function wrapped with `once` shouln't be called more than once"
+}
+
 module.exports = wrappy(once)
 
 once.proto = once(function () {
@@ -8,14 +20,24 @@ once.proto = once(function () {
     },
     configurable: true
   })
+
+  Object.defineProperty(Function.prototype, 'strictOnce', {
+    value: function () {
+      return once.strict(this)
+    },
+    configurable: true
+  })
 })
 
-function once (fn) {
-  var f = function () {
-    if (f.called) return f.value
-    f.called = true
-    return f.value = fn.apply(this, arguments)
+function secondCallHandler (onSecondCall) {
+  return function (fn) {
+    var f = function () {
+      if (f.called) return onSecondCall(f)
+      f.called = true
+      return f.value = fn.apply(this, arguments)
+    }
+    f.srcName = fn.name
+    f.called = false
+    return f
   }
-  f.called = false
-  return f
 }

--- a/test/once.js
+++ b/test/once.js
@@ -21,3 +21,71 @@ test('once', function (t) {
   }
   t.end()
 })
+
+test('once.strict with named function', function (t) {
+  var f = 0
+  function fn (g) {
+    t.equal(f, 0)
+    f ++
+    return f + g + this
+  }
+  fn.ownProperty = {}
+  var foo = once.strict(fn)
+  t.equal(fn.ownProperty, foo.ownProperty)
+  t.notOk(foo.called)
+
+  var g = foo.call(1, 1)
+  t.ok(foo.called)
+  t.same(g, 3)
+  t.same(f, 1)
+
+  try {
+    foo.call(2, 2)
+    t.fail('strict once should throw exception on second call')
+  } catch (err) {
+    t.ok(err instanceof Error)
+    t.equal(err.message, "fn shouln't be called more than once")
+    t.end()
+  }
+})
+
+test('once.strict with anonymous function', function (t) {
+  var foo = once.strict(function (g) {
+    return g + 1
+  })
+  t.notOk(foo.called)
+
+  var g = foo(1)
+  t.ok(foo.called)
+  t.same(g, 2)
+
+  try {
+    foo(2)
+    t.fail('strict once should throw exception on second call')
+  } catch (err) {
+    t.ok(err instanceof Error)
+    t.equal(err.message, "Function wrapped with `once` shouln't be called more than once")
+    t.end()
+  }
+})
+
+test('once.strict with custom error message', function (t) {
+  var foo = once.strict(function (g) {
+    return g + 1
+  })
+  foo.onceError = 'foo error'
+  t.notOk(foo.called)
+
+  var g = foo(1)
+  t.ok(foo.called)
+  t.same(g, 2)
+
+  try {
+    foo(2)
+    t.fail('strict once should throw exception on second call')
+  } catch (err) {
+    t.ok(err instanceof Error)
+    t.equal(err.message, 'foo error')
+    t.end()
+  }
+})


### PR DESCRIPTION
I would love to be able to use a strict version of `once` that would throw an error when called more than once. IMHO, it would be a good extension. More details in the new section of the README.

A real world use case is in my `pre-hook` module where an error is thrown when the `next` function is called more than once ([related unit test](https://github.com/zkochan/magic-hook/blob/master/test/index.js#L106))